### PR TITLE
Award a badge for a specific topic

### DIFF
--- a/badgeos-learndash.php
+++ b/badgeos-learndash.php
@@ -5,7 +5,7 @@
  * Description: This BadgeOS add-on integrates BadgeOS features with LearnDash
  * Tags: learndash
  * Author: Credly
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author URI: https://credly.com/
  * License: GNU AGPLv3
  * License URI: http://www.gnu.org/licenses/agpl-3.0.html

--- a/badgeos-learndash.php
+++ b/badgeos-learndash.php
@@ -27,6 +27,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>;.
 */
 
+/*
+ * Bug-fix/Edited by Natalia Chriss (Github: nat-c | Email: contact@nataliachriss.com)
+*/
+
 class BadgeOS_LearnDash {
 
 	/**

--- a/includes/rules-engine.php
+++ b/includes/rules-engine.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Custom Achievement Rules
+ * Custom Achievement Rules.
  *
  * @package BadgeOS LearnDash
  * @subpackage Achievements
@@ -10,7 +10,7 @@
  */
 
 /**
- * Load up our LearnDash triggers so we can add actions to them
+ * Load up our LearnDash triggers so we can add actions to them.
  *
  * @since 1.0.0
  */
@@ -39,7 +39,7 @@ function badgeos_learndash_load_triggers() {
 add_action( 'init', 'badgeos_learndash_load_triggers' );
 
 /**
- * Handle each of our LearnDash triggers
+ * Handle each of our LearnDash triggers.
  *
  * @since 1.0.0
  */
@@ -53,12 +53,12 @@ function badgeos_learndash_trigger_event() {
 
 	$userID = get_current_user_id();
 
-	if ( is_array( $args ) && isset( $args[ 'user' ] ) ) {
-		if ( is_object( $args[ 'user' ] ) ) {
-			$userID = (int) $args[ 'user' ]->ID;
+	if ( is_array( $args ) && isset( $args[ 0 ] ) && isset( $args[ 0 ][ 'user' ] ) ) {
+		if ( is_object( $args[ 0 ][ 'user' ] ) ) {
+			$userID = (int) $args[ 0 ][ 'user' ]->ID;
 		}
 		else {
-			$userID = (int) $args[ 'user' ];
+			$userID = (int) $args[ 0 ][ 'user' ];
 		}
 	}
 
@@ -95,18 +95,18 @@ function badgeos_learndash_trigger_event() {
 }
 
 /**
- * Check if user deserves a LearnDash trigger step
+ * Check if user deserves a LearnDash trigger step.
  *
  * @since  1.0.0
  *
- * @param  bool $return         Whether or not the user deserves the step
- * @param  integer $user_id        The given user's ID
- * @param  integer $achievement_id The given achievement's post ID
- * @param  string $trigger        The trigger
- * @param  integer $site_id        The triggered site id
- * @param  array $args        The triggered args
+ * @param  bool    $return         Whether or not the user deserves the step.
+ * @param  integer $user_id        The given user's ID.
+ * @param  integer $achievement_id The given achievement's post ID.
+ * @param  string  $this_trigger   The trigger.
+ * @param  integer $site_id        The triggered site id.
+ * @param  array   $args           The triggered args.
  *
- * @return bool                    True if the user deserves the step, false otherwise
+ * @return bool                    True if the user deserves the step, false otherwise.
  */
 function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $achievement_id, $this_trigger = '', $site_id = 1, $args = array() ) {
 
@@ -143,12 +143,12 @@ function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $ach
 
 		// Object-specific triggers
 		$learndash_object_triggers = array(
-			'learndash_quiz_completed',
-			'badgeos_learndash_quiz_completed_specific',
-			'badgeos_learndash_quiz_completed_fail',
-			'learndash_lesson_completed',
-			'learndash_course_completed',
-			'learndash_topic_completed'
+			'learndash_quiz_completed' => 'quiz',
+			'badgeos_learndash_quiz_completed_specific' => 'quiz',
+			'badgeos_learndash_quiz_completed_fail' => 'quiz',
+			'learndash_lesson_completed' => 'lesson',
+			'learndash_topic_completed' => 'topic',
+			'learndash_course_completed' => 'course'
 		);
 
 		// Category-specific triggers
@@ -156,28 +156,13 @@ function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $ach
 			'badgeos_learndash_course_completed_tag'
 		);
 
-		// Quiz-specific triggers
-		$learndash_quiz_triggers = array(
-			'learndash_quiz_completed',
-			'badgeos_learndash_quiz_completed_specific',
-			'badgeos_learndash_quiz_completed_fail'
-		);
-
 		// Triggered object ID (used in these hooks, generally 2nd arg)
 		$triggered_object_id = 0;
 
 		$arg_data = $args[ 0 ];
 
-		if ( is_array( $arg_data ) ) {
-			if ( isset( $arg_data[ 'quiz' ] ) ) {
-				$triggered_object_id = (int) $arg_data[ 'quiz' ]->ID;
-			}
-			elseif ( isset( $arg_data[ 'lesson' ] ) ) {
-				$triggered_object_id = (int) $arg_data[ 'lesson' ]->ID;
-			}
-			elseif ( isset( $arg_data[ 'course' ] ) ) {
-				$triggered_object_id = (int) $arg_data[ 'course' ]->ID;
-			}
+		if ( is_array( $arg_data ) && isset( $learndash_object_triggers[ $learndash_trigger ] ) && isset( $arg_data[ $learndash_object_triggers[ $learndash_trigger ] ] ) && !empty( $arg_data[ $learndash_object_triggers[ $learndash_trigger ] ] ) ) {
+			$triggered_object_id = (int) $arg_data[ $learndash_object_triggers[ $learndash_trigger ] ]->ID;
 		}
 
 		// Use basic trigger logic if no object set
@@ -185,7 +170,7 @@ function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $ach
 			$learndash_triggered = true;
 		}
 		// Object specific
-		elseif ( in_array( $learndash_trigger, $learndash_object_triggers ) && $triggered_object_id == $object_id ) {
+		elseif ( $triggered_object_id == $object_id ) {
 			$learndash_triggered = true;
 
 			// Forcing count due to BadgeOS bug tracking triggers properly
@@ -200,7 +185,7 @@ function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $ach
 		}
 
 		// Quiz triggers
-		if ( $learndash_triggered && in_array( $learndash_trigger, $learndash_quiz_triggers ) ) {
+		if ( $learndash_triggered && isset( $learndash_object_triggers[ $learndash_trigger ] ) && 'quiz' == $learndash_object_triggers[ $learndash_trigger ] ) {
 			// Check for fail
 			if ( 'badgeos_learndash_quiz_completed_fail' == $learndash_trigger ) {
 				if ( $arg_data[ 'pass' ] ) {
@@ -232,6 +217,12 @@ function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $ach
 				// OK, you can pass go now
 				$return = true;
 			}
+		}
+
+		if ( $learndash_triggered && $return ) {
+			$user_data = get_userdata( $user_id );
+
+			badgeos_post_log_entry( null, $user_id, null, sprintf( __( '%1$s deserves %2$s', 'badgeos' ), $user_data->user_login, $this_trigger ) );
 		}
 	}
 

--- a/includes/steps-ui.php
+++ b/includes/steps-ui.php
@@ -311,7 +311,7 @@ function badgeos_learndash_save_step( $title, $step_id, $step_data ) {
 		// Topic specific
 		elseif ( 'learndash_topic_completed' == $step_data[ 'learndash_trigger' ] ) {
 			// Get Object ID
-			$object_id = (int) $step_data[ 'learndash_lesson_id' ];
+			$object_id = (int) $step_data[ 'learndash_topic_id' ];
 
 			// Set new step title
 			if ( empty( $object_id ) ) {
@@ -421,7 +421,7 @@ function badgeos_learndash_step_js() {
 
 				step_details.learndash_quiz_id = $( '.select-quiz-id', step ).val();
 				step_details.learndash_quiz_grade = $( '.input-quiz-grade', step ).val();
-				step_details.learndash_lesson_id = $( '.select-topic-id', step ).val();
+				step_details.learndash_topic_id = $( '.select-topic-id', step ).val();
 				step_details.learndash_lesson_id = $( '.select-lesson-id', step ).val();
 				step_details.learndash_course_id = $( '.select-course-id', step ).val();
 				step_details.learndash_course_category_id = $( '.select-course-category-id', step ).val();

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,10 @@ In addition to all of the out-of-the-box features in BadgeOS core, the BadgeOS L
    *   Complete a specific Lesson
    *   Complete any Lesson
 
+*   **Topic:**
+
+   *   Complete a specific Topic
+
 *   **Quizzes:**
 
    *   Pass a specific Quiz
@@ -131,11 +135,17 @@ Thanks for asking!  Please do share back code modifications or enhancements you 
 
 == Changelog ==
 
+= 1.0.1 =
+* Earn badges for completing specific topics.
+
 = 1.0 =
 * BadgeOS LearnDash Add-on says "hello learndash", earns "Hello LearnDash" badge.
 
 
 == Upgrade Notice ==
+
+= 1.0.1 =
+* Bug fix
 
 = 1.0 =
 * Initial release

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,7 @@ In addition to all of the out-of-the-box features in BadgeOS core, the BadgeOS L
 *   **Topic:**
 
    *   Complete a specific Topic
+   *   Complete any Topic
 
 *   **Quizzes:**
 
@@ -136,7 +137,7 @@ Thanks for asking!  Please do share back code modifications or enhancements you 
 == Changelog ==
 
 = 1.0.1 =
-* Earn badges for completing specific topics.
+* Earn badges for completing specific topics. --Edit by Natalia Chriss (nat-c)
 
 = 1.0 =
 * BadgeOS LearnDash Add-on says "hello learndash", earns "Hello LearnDash" badge.


### PR DESCRIPTION
Fixes the bug described here:
https://wordpress.org/support/topic/how-to-add-a-trigger-for-completing-a-lesson-topic/#post-5248741

(and here: https://wordpress.org/support/topic/badges-for-topics/ )